### PR TITLE
Fix hash invocations through hashable instances (#232)

### DIFF
--- a/Fambda/Core/Either/Either.cs
+++ b/Fambda/Core/Either/Either.cs
@@ -67,7 +67,7 @@ namespace Fambda
         /// </summary>
         /// <returns>A hash code for the current <see cref="Either{L,R}"/> object.</returns>
         public override int GetHashCode()
-            => default(HashableEither<L, R>).GetHashCode();
+            => default(HashableEither<L, R>).GetHashCode(this);
 
         /// <summary>
         /// Indicates whether the current <see cref="Either{L,R}"/> is equal to another <see cref="Either{L,R}"/>

--- a/Fambda/Core/Option/Option.cs
+++ b/Fambda/Core/Option/Option.cs
@@ -71,7 +71,7 @@ namespace Fambda
         /// </summary>
         /// <returns>A hash code for the current <see cref="Option{T}"/> object.</returns>
         public override int GetHashCode()
-            => default(HashableOption<T>).GetHashCode();
+            => default(HashableOption<T>).GetHashCode(this);
 
         /// <summary>
         /// Indicates whether the current <see cref="Option{T}"/> is equal to another <see cref="Option{T}"/>


### PR DESCRIPTION
remarks:
 - fixes GetHashCode to use concrete
   hashable instance that provides
   correct hash