### PR TITLE
Definition convention with self (#260)

### DIFF
--- a/Fambda/Core/Either/EitherExt.cs
+++ b/Fambda/Core/Either/EitherExt.cs
@@ -11,19 +11,19 @@ namespace Fambda
         /// <summary>
         /// Maps <see cref="Either{T,R}"/> into <see cref="Either{L,RRes}"/>
         /// </summary>
-        public static Either<L, RRes> Map<L, R, RRes>(this Either<L, R> either, Func<R, RRes> func)
-            => either.Match<Either<L, RRes>>(
-                        Left: (left) => Left(left),
-                        Right: (right) => Right(func(right))
-                      );
+        public static Either<L, RRes> Map<L, R, RRes>(this Either<L, R> self, Func<R, RRes> func)
+            => self.Match<Either<L, RRes>>(
+                      Left: (left) => Left(left),
+                      Right: (right) => Right(func(right))
+                    );
 
         /// <summary>
         /// Binds <see cref="Either{T,R}"/> into <see cref="Either{L,RRes}"/>
         /// </summary>
-        public static Either<L, RRes> Bind<L, R, RRes>(this Either<L, R> either, Func<R, Either<L, RRes>> func)
-            => either.Match<Either<L, RRes>>(
-                        Left: (left) => Left(left),
-                        Right: (right) => func(right)
-                      );
+        public static Either<L, RRes> Bind<L, R, RRes>(this Either<L, R> self, Func<R, Either<L, RRes>> func)
+            => self.Match<Either<L, RRes>>(
+                      Left: (left) => Left(left),
+                      Right: (right) => func(right)
+                    );
     }
 }

--- a/Fambda/Core/Enumerable/EnumerableExt.cs
+++ b/Fambda/Core/Enumerable/EnumerableExt.cs
@@ -12,20 +12,20 @@ namespace Fambda
         /// <summary>
         /// Maps <see cref="IEnumerable{T}"/> into <see cref="IEnumerable{Res}"/>
         /// </summary>
-        public static IEnumerable<Res> Map<T, Res>(this IEnumerable<T> enumerable, Func<T, Res> func)
-            => enumerable.Select(func);
+        public static IEnumerable<Res> Map<T, Res>(this IEnumerable<T> self, Func<T, Res> func)
+            => self.Select(func);
 
         /// <summary>
         /// Binds <see cref="IEnumerable{T}"/> into <see cref="IEnumerable{Res}"/>
         /// </summary>
-        public static IEnumerable<Res> Bind<T, Res>(this IEnumerable<T> enumerable, Func<T, IEnumerable<Res>> func)
-            => enumerable.SelectMany(func);
+        public static IEnumerable<Res> Bind<T, Res>(this IEnumerable<T> self, Func<T, IEnumerable<Res>> func)
+            => self.SelectMany(func);
 
         /// <summary>
         /// <para>Flattens <see cref="IEnumerable{T}">IEnumerable&lt;IEnumerable&lt;T>></see> into <see cref="IEnumerable{T}">IEnumerable&lt;T></see>.</para>
         /// <para><c>IEnumerable&lt;IEnumerable&lt;T>> → IEnumerable&lt;T></c></para>
         /// </summary>
-        public static IEnumerable<T> Flatten<T>(this IEnumerable<IEnumerable<T>> enumerable)
-            => enumerable.SelectMany(x => x);
+        public static IEnumerable<T> Flatten<T>(this IEnumerable<IEnumerable<T>> self)
+            => self.SelectMany(x => x);
     }
 }

--- a/Fambda/Core/Exceptional/ExceptionalExt.cs
+++ b/Fambda/Core/Exceptional/ExceptionalExt.cs
@@ -12,8 +12,8 @@ namespace Fambda
         /// <summary>
         /// Maps <see cref="Exceptional{T}"/> into <see cref="Exceptional{Res}"/>
         /// </summary>
-        public static Exceptional<Res> Map<R, Res>(this Exceptional<R> exceptional, Func<R, Res> func)
-            => exceptional.Exception == null ? func(exceptional.Value) : new Exceptional<Res>(exceptional.Exception);
+        public static Exceptional<Res> Map<R, Res>(this Exceptional<R> self, Func<R, Res> func)
+            => self.Exception == null ? func(self.Value) : new Exceptional<Res>(self.Exception);
 
         #endregion
 
@@ -22,8 +22,8 @@ namespace Fambda
         /// <summary>
         /// Binds <see cref="Exceptional{T}"/> into <see cref="Exceptional{Res}"/>
         /// </summary>
-        public static Exceptional<Res> Bind<R, Res>(this Exceptional<R> exceptional, Func<R, Exceptional<Res>> func)
-            => exceptional.Exception == null ? func(exceptional.Value) : new Exceptional<Res>(exceptional.Exception);
+        public static Exceptional<Res> Bind<R, Res>(this Exceptional<R> self, Func<R, Exceptional<Res>> func)
+            => self.Exception == null ? func(self.Value) : new Exceptional<Res>(self.Exception);
 
         #endregion
 
@@ -35,17 +35,17 @@ namespace Fambda
         /// </summary>
         /// <typeparam name="T">The type of wrapped function's parameter.</typeparam>
         /// <typeparam name="Res">The type of the wrapped function's return value.</typeparam>
-        /// <param name="exceptionalF">The exceptional containing the function <see cref="Func{T, Res}"/> to be applied on the applicative.</param>
-        /// <param name="exceptionalT">The exceptional containing the value of type <c>T</c>, on which the function <see cref="Func{T, Res}"/> will be applied.</param>
+        /// <param name="self">The exceptional containing the function <see cref="Func{T, Res}"/> to be applied on the applicative.</param>
+        /// <param name="exceptional">The exceptional containing the value of type <c>T</c>, on which the function <see cref="Func{T, Res}"/> will be applied.</param>
         /// <returns>The result of type <c>Res</c> wrapped in an <c>Exceptional</c> applicative (<see cref="Exceptional{T}">Exceptional&lt;Res&gt;</see>).</returns>
-        public static Exceptional<Res> Apply<T, Res>(this Exceptional<Func<T, Res>> exceptionalF, Exceptional<T> exceptionalT)
-           => exceptionalF.Match(
-                              Exception: ex => ex,
-                              Success: func => exceptionalT.Match(
-                                                              Exception: ex => ex,
-                                                              Success: t => new Exceptional<Res>(func(t))
-                                                            )
-                           );
+        public static Exceptional<Res> Apply<T, Res>(this Exceptional<Func<T, Res>> self, Exceptional<T> exceptional)
+           => self.Match(
+                     Exception: ex => ex,
+                     Success: func => exceptional.Match(
+                                                    Exception: ex => ex,
+                                                    Success: t => new Exceptional<Res>(func(t))
+                                                  )
+                   );
 
         /// <summary>
         /// <para>Apply function <see cref="Func{T1, T2, Res}">Func&lt;T1, T2, Res&gt;</see> to <see cref="Exceptional{T}">Exceptional&lt;T1&gt;</see>'s unwrapped value of type <c>T1</c>, and wrap the result <see cref="Func{T2, Res}">Func&lt;T2, Res&gt;</see> back in an <c>Exceptional</c> (<see cref="Exceptional{T}">Exceptional&lt;Func&lt;T2, Res&gt;&gt;</see>).</para>
@@ -54,11 +54,11 @@ namespace Fambda
         /// <typeparam name="T1">The type of wrapped function's first parameter.</typeparam>
         /// <typeparam name="T2">The type of wrapped function's second parameter.</typeparam>
         /// <typeparam name="Res">The type of the wrapped function's return value.</typeparam>
-        /// <param name="exceptionalF">The exceptional containing the function <see cref="Func{T1, T2, Res}"/> to be applied on the applicative.</param>
-        /// <param name="exceptionalT1">The exceptional containing the value of type <c>T1</c>, on which the function <see cref="Func{T1, T2, Res}"/> will be applied.</param>
+        /// <param name="self">The exceptional containing the function <see cref="Func{T1, T2, Res}"/> to be applied on the applicative.</param>
+        /// <param name="exceptional">The exceptional containing the value of type <c>T1</c>, on which the function <see cref="Func{T1, T2, Res}"/> will be applied.</param>
         /// <returns>An unary function <see cref="Func{T2, Res}">Func&lt;T2, Res&gt;</see> wrapped in an <c>Exceptional</c> applicative (<see cref="Exceptional{T}">Exceptional&lt;Func&lt;T2, Res&gt;&gt;</see>).</returns>
-        public static Exceptional<Func<T2, Res>> Apply<T1, T2, Res>(this Exceptional<Func<T1, T2, Res>> exceptionalF, Exceptional<T1> exceptionalT1)
-           => Apply(exceptionalF.Map(F.Curry), exceptionalT1);
+        public static Exceptional<Func<T2, Res>> Apply<T1, T2, Res>(this Exceptional<Func<T1, T2, Res>> self, Exceptional<T1> exceptional)
+           => Apply(self.Map(F.Curry), exceptional);
 
         #endregion
 

--- a/Fambda/Core/Option/OptionExt.cs
+++ b/Fambda/Core/Option/OptionExt.cs
@@ -15,18 +15,18 @@ namespace Fambda
         /// <para>Maps <see cref="Option{T}">Option&lt;T></see> into <see cref="Option{T}">Option&lt;Res></see>.</para>
         /// <para><c>Option&lt;T> → (T → Res) → Option&lt;Res></c></para>
         /// </summary>
-        public static Option<Res> Map<T, Res>(this Option<T> option, Func<T, Res> func)
-            => option.Match(
-                        None: () => None,
-                        Some: (t) => Some(func(t))
-                      );
+        public static Option<Res> Map<T, Res>(this Option<T> self, Func<T, Res> func)
+            => self.Match(
+                      None: () => None,
+                      Some: (t) => Some(func(t))
+                    );
 
         /// <summary>
         /// <para>Maps <see cref="Option{T}">Option&lt;T1></see> into <see cref="Option{T}">Option&lt;Func&lt;T2,Res>></see>.</para>
         /// <para><c>Option&lt;T1> → (T1 → T2 → Res) → Option&lt;T2 → Res></c></para>
         /// </summary>
-        public static Option<Func<T2, Res>> Map<T1, T2, Res>(this Option<T1> option, Func<T1, T2, Res> func)
-            => option.Map(F.Curry(func));
+        public static Option<Func<T2, Res>> Map<T1, T2, Res>(this Option<T1> self, Func<T1, T2, Res> func)
+            => self.Map(F.Curry(func));
 
         #endregion
 
@@ -36,11 +36,11 @@ namespace Fambda
         /// <para>Binds <see cref="Option{T}">Option&lt;T></see> into <see cref="Option{T}">Option&lt;Res></see>.</para>
         /// <para><c>Option&lt;T> → (T → Option&lt;Res>) → Option&lt;Res></c></para>
         /// </summary>
-        public static Option<Res> Bind<T, Res>(this Option<T> option, Func<T, Option<Res>> func)
-            => option.Match(
-                        None: () => None,
-                        Some: (t) => func(t)
-                      );
+        public static Option<Res> Bind<T, Res>(this Option<T> self, Func<T, Option<Res>> func)
+            => self.Match(
+                      None: () => None,
+                      Some: (t) => func(t)
+                    );
 
         #endregion
 
@@ -52,17 +52,17 @@ namespace Fambda
         /// </summary>
         /// <typeparam name="T">The type of wrapped function's parameter.</typeparam>
         /// <typeparam name="Res">The type of the wrapped function's return value.</typeparam>
-        /// <param name="optionF">The option containing the function <see cref="Func{T, Res}"/> to be applied on the applicative.</param>
-        /// <param name="optionT">The option containing the value of type <c>T</c>, on which the function <see cref="Func{T, Res}"/> will be applied.</param>
+        /// <param name="self">The option containing the function <see cref="Func{T, Res}"/> to be applied on the applicative.</param>
+        /// <param name="option">The option containing the value of type <c>T</c>, on which the function <see cref="Func{T, Res}"/> will be applied.</param>
         /// <returns>The result of type <c>Res</c> wrapped in an <c>Option</c> applicative (<see cref="Option{T}">Option&lt;Res&gt;</see>).</returns>
-        public static Option<Res> Apply<T, Res>(this Option<Func<T, Res>> optionF, Option<T> optionT)
-           => optionF.Match(
-                          None: () => None,
-                          Some: func => optionT.Match(
-                                                  None: () => None,
-                                                  Some: t => Some(func(t))
-                                               )
-                      );
+        public static Option<Res> Apply<T, Res>(this Option<Func<T, Res>> self, Option<T> option)
+           => self.Match(
+                     None: () => None,
+                     Some: func => option.Match(
+                                            None: () => None,
+                                            Some: t => Some(func(t))
+                                          )
+                   );
 
         /// <summary>
         /// <para>Apply function <see cref="Func{T1, T2, Res}">Func&lt;T1, T2, Res&gt;</see> to <see cref="Option{T}">Option&lt;T1&gt;</see>'s unwrapped value of type <c>T1</c>, and wrap the result <see cref="Func{T2, Res}">Func&lt;T2, Res&gt;</see> back in an <c>Option</c> (<see cref="Option{T}">Option&lt;Func&lt;T2, Res&gt;&gt;</see>).</para>
@@ -71,11 +71,11 @@ namespace Fambda
         /// <typeparam name="T1">The type of wrapped function's first parameter.</typeparam>
         /// <typeparam name="T2">The type of wrapped function's second parameter.</typeparam>
         /// <typeparam name="Res">The type of the wrapped function's return value.</typeparam>
-        /// <param name="optionF">The option containing the function <see cref="Func{T1, T2, Res}"/> to be applied on the applicative.</param>
-        /// <param name="optionT1">The option containing the value of type <c>T1</c>, on which the function <see cref="Func{T1, T2, Res}"/> will be applied.</param>
+        /// <param name="self">The option containing the function <see cref="Func{T1, T2, Res}"/> to be applied on the applicative.</param>
+        /// <param name="option">The option containing the value of type <c>T1</c>, on which the function <see cref="Func{T1, T2, Res}"/> will be applied.</param>
         /// <returns>An unary function <see cref="Func{T2, Res}">Func&lt;T2, Res&gt;</see> wrapped in an <c>Option</c> applicative (<see cref="Option{T}">Option&lt;Func&lt;T2, Res&gt;&gt;</see>).</returns>
-        public static Option<Func<T2, Res>> Apply<T1, T2, Res>(this Option<Func<T1, T2, Res>> optionF, Option<T1> optionT1)
-           => Apply(optionF.Map(F.Curry), optionT1);
+        public static Option<Func<T2, Res>> Apply<T1, T2, Res>(this Option<Func<T1, T2, Res>> self, Option<T1> option)
+           => Apply(self.Map(F.Curry), option);
 
         #endregion
 
@@ -84,30 +84,30 @@ namespace Fambda
         /// <summary>
         /// Projects map <see cref="Option{T}"/> into <see cref="Option{Res}"/>.
         /// </summary>
-        public static Option<Res> Select<T, Res>(this Option<T> option, Func<T, Res> func)
-            => option.Map(func);
+        public static Option<Res> Select<T, Res>(this Option<T> self, Func<T, Res> func)
+            => self.Map(func);
 
         /// <summary>
         /// Projects bind <see cref="Option{T}"/> into <see cref="Option{Res}"/>.
         /// </summary>
-        public static Option<Res> SelectMany<T, Res>(this Option<T> option, Func<T, Option<Res>> func)
-            => option.Bind(func);
+        public static Option<Res> SelectMany<T, Res>(this Option<T> self, Func<T, Option<Res>> func)
+            => self.Bind(func);
 
         /// <summary>
         /// Projects <see cref="Option{T}"/> into <see cref="Option{Res}"/>.
         /// </summary>
-        public static Option<Res> SelectMany<T, R, Res>(this Option<T> option, Func<T, Option<R>> func, Func<T, R, Res> project)
-            => option.Bind(t => func(t).Map(c => project(t, c)));
+        public static Option<Res> SelectMany<T, R, Res>(this Option<T> self, Func<T, Option<R>> func, Func<T, R, Res> project)
+            => self.Bind(t => func(t).Map(c => project(t, c)));
 
         /// <summary>
         /// Applies a predicate to the bound value.
         /// </summary>
         /// <returns><see cref="OptionSome{T}"/> if the option is in a Some state and <paramref name="pred"/> predicate returns true; otherwise, <see cref="OptionNone"/>.</returns>
-        public static Option<T> Where<T>(this Option<T> option, Func<T, bool> pred)
-            => option.Match(
-                        None: () => None,
-                        Some: (t) => pred(t) ? option : None
-                      );
+        public static Option<T> Where<T>(this Option<T> self, Func<T, bool> pred)
+            => self.Match(
+                      None: () => None,
+                      Some: (t) => pred(t) ? self : None
+                    );
 
         #endregion
 
@@ -117,11 +117,11 @@ namespace Fambda
         /// Converts <see cref="Option{T}"/> into <see cref="IEnumerable{T}"/> with one or no items.
         /// </summary>
         /// <returns><see cref="IEnumerable{T}"/> with one or no items.</returns>
-        public static IEnumerable<T> AsEnumerable<T>(this Option<T> option)
-            => option.Match(
-                        None: () => Enumerable.Empty<T>(),
-                        Some: (t) => { return new List<T>() { t }; }
-                      );
+        public static IEnumerable<T> AsEnumerable<T>(this Option<T> self)
+            => self.Match(
+                      None: () => Enumerable.Empty<T>(),
+                      Some: (t) => { return new List<T>() { t }; }
+                    );
 
         #endregion
     }

--- a/Fambda/Core/Try/TryExt.cs
+++ b/Fambda/Core/Try/TryExt.cs
@@ -13,11 +13,11 @@ namespace Fambda
         /// </summary>
         /// <returns><see cref="Exceptional{T}"/> Exception or Success.</returns>
         [Pure]
-        public static Exceptional<T> Try<T>(this Try<T> @try)
+        public static Exceptional<T> Try<T>(this Try<T> self)
         {
             try
             {
-                return @try();
+                return self();
             }
             catch (Exception exception)
             {
@@ -28,8 +28,8 @@ namespace Fambda
         /// <summary>
         /// Maps <see cref="Try{T}"/> into <see cref="Try{Res}"/>
         /// </summary>
-        public static Try<Res> Map<T, Res>(this Try<T> @try, Func<T, Res> func)
-            => () => @try.Try()
+        public static Try<Res> Map<T, Res>(this Try<T> self, Func<T, Res> func)
+            => () => self.Try()
                          .Match<Exceptional<Res>>(
                             Exception: ex => ex,
                             Success: t => func(t)
@@ -38,8 +38,8 @@ namespace Fambda
         /// <summary>
         /// Binds <see cref="Try{T}"/> into <see cref="Try{Res}"/>
         /// </summary>
-        public static Try<Res> Bind<T, Res>(this Try<T> @try, Func<T, Try<Res>> func)
-            => () => @try.Try()
+        public static Try<Res> Bind<T, Res>(this Try<T> self, Func<T, Try<Res>> func)
+            => () => self.Try()
                          .Match(
                              Exception: ex => ex,
                              Success: t => func(t).Try()


### PR DESCRIPTION
notes:
 - simplification through this convention applied
   on definitions of data types` extensions
   Enumerable, Option, Either, Try, Exceptional