### PR TITLE
Parse transformations (#262)

### DIFF
--- a/Fambda.Tests/Core/BoolTypeTests.cs
+++ b/Fambda.Tests/Core/BoolTypeTests.cs
@@ -10,7 +10,7 @@ namespace Fambda
         #region Parse
 
         [Fact]
-        public void ParseShouldReturnOptionBoolNone()
+        public void Parse_ReturnsOptionBoolNone()
         {
             // Arrange
             var value = "not an logical boolean";
@@ -30,7 +30,7 @@ namespace Fambda
         [InlineData("False", false)]
         [InlineData("false", false)]
         [InlineData("fAlse", false)]
-        public void ParseShouldReturnOptionBoolSome(string stringBool, bool expectedBool)
+        public void Parse_ReturnsOptionBoolSome(string stringBool, bool expectedBool)
         {
             // Arrange
             var value = stringBool;

--- a/Fambda.Tests/Core/CharTypeTests.cs
+++ b/Fambda.Tests/Core/CharTypeTests.cs
@@ -10,7 +10,7 @@ namespace Fambda
         #region Parse
 
         [Fact]
-        public void ParseShouldReturnOptionCharNone()
+        public void Parse_ReturnsOptionCharNone()
         {
             // Arrange
             var s = "not a char";
@@ -24,7 +24,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionCharSome()
+        public void Parse_ReturnsOptionCharSome()
         {
             // Arrange
             var s = "A";

--- a/Fambda.Tests/Core/DateTimeTypeTests.cs
+++ b/Fambda.Tests/Core/DateTimeTypeTests.cs
@@ -12,7 +12,7 @@ namespace Fambda
         #region Parse
 
         [Fact]
-        public void ParseShouldReturnOptionDateTimeNone()
+        public void Parse_ReturnsOptionDateTimeNone()
         {
             // Arrange
             var s = "not a date and time";
@@ -26,7 +26,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionDateTimeSome()
+        public void Parse_ReturnsOptionDateTimeSome()
         {
             // Arrange
             var dateTime = DateTime.Now;
@@ -41,7 +41,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionDateTimeNone()
+        public void Parse_WithFormatProvider_ReturnsOptionDateTimeNone()
         {
             // Arrange
             var s = "2021-06-21 17:35";
@@ -57,7 +57,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionDateTimeSome()
+        public void Parse_WithFormatProvider_ReturnsOptionDateTimeSome()
         {
             // Arrange
             var dateTime = DateTime.Now;

--- a/Fambda.Tests/Core/DecimalTypeTests.cs
+++ b/Fambda.Tests/Core/DecimalTypeTests.cs
@@ -12,7 +12,7 @@ namespace Fambda
         #region Parse
 
         [Fact]
-        public void ParseShouldReturnOptionDecimalNone()
+        public void Parse_ReturnsOptionDecimalNone()
         {
             // Arrange
             var s = "not a decimal";
@@ -26,7 +26,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionDecimalSome()
+        public void Parse_ReturnsOptionDecimalSome()
         {
             // Arrange
             var s = "1";
@@ -40,7 +40,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionDecimalNone()
+        public void Parse_WithNumberStyles_ReturnsOptionDecimalNone()
         {
             // Arrange
             var s = "not a decimal";
@@ -54,7 +54,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionDecimalSome()
+        public void Parse_WithNumberStyles_ReturnsOptionDecimalSome()
         {
             // Arrange
             var s = "1.1";
@@ -68,7 +68,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionDecimalNoneWhenStringIsNotExpectedHexNumber()
+        public void Parse_WithNumberStylesWhenStringIsNotExpectedHexNumber_ReturnsOptionDecimalNone()
         {
             // Arrange
             var s = "1.1";
@@ -82,7 +82,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionDecimalNone()
+        public void Parse_WithFormatProvider_ReturnsOptionDecimalNone()
         {
             // Arrange
             var s = "positive1234.1";
@@ -98,7 +98,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionDecimalSome()
+        public void Parse_WithFormatProvider_ReturnsOptionDecimalSome()
         {
             // Arrange
             var s = "p1234";
@@ -114,7 +114,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesAndFormatProviderShouldReturnOptionDecimalNone()
+        public void Parse_WithNumberStylesAndFormatProvider_ReturnsOptionDecimalNone()
         {
             // Arrange
             var s = "p1$234.4";
@@ -129,7 +129,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesAndFormatProviderShouldReturnOptionDecimalSome()
+        public void Parse_WithNumberStylesAndFormatProvider_ReturnsOptionDecimalSome()
         {
             // Arrange
             var s = "p1.1";

--- a/Fambda.Tests/Core/DoubleTypeTests.cs
+++ b/Fambda.Tests/Core/DoubleTypeTests.cs
@@ -12,7 +12,7 @@ namespace Fambda
         #region Parse
 
         [Fact]
-        public void ParseShouldReturnOptionDoubleNone()
+        public void Parse_ReturnsOptionDoubleNone()
         {
             // Arrange
             var s = "not a double";
@@ -26,7 +26,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionDoubleSome()
+        public void Parse_ReturnsOptionDoubleSome()
         {
             // Arrange
             var s = "1.1";
@@ -40,7 +40,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionDoubleNone()
+        public void Parse_WithNumberStyles_ReturnsOptionDoubleNone()
         {
             // Arrange
             var s = "not a double";
@@ -54,7 +54,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionDoubleSome()
+        public void Parse_WithNumberStyles_ReturnsOptionDoubleSome()
         {
             // Arrange
             var s = "1.1";
@@ -68,7 +68,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionDoubleNoneWhenStringIsNotExpectedHexNumber()
+        public void Parse_WithNumberStylesWhenStringIsNotExpectedHexNumber_ReturnsOptionDoubleNone()
         {
             // Arrange
             var s = "1.0";
@@ -82,7 +82,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionDoubleNone()
+        public void Parse_WithFormatProvider_ReturnsOptionDoubleNone()
         {
             // Arrange
             var s = "positive1234.5";
@@ -98,7 +98,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionDoubleSome()
+        public void Parse_WithFormatProvider_ReturnsOptionDoubleSome()
         {
             // Arrange
             var s = "p1234.5";
@@ -114,7 +114,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesAndFormatProviderShouldReturnOptionDoubleNone()
+        public void Parse_WithNumberStylesAndFormatProvider_ReturnsOptionDoubleNone()
         {
             // Arrange
             var s = "p1$234.5";
@@ -129,7 +129,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesAndFormatProviderShouldReturnOptionDoubleSome()
+        public void Parse_WithNumberStylesAndFormatProvider_ReturnOptionDoubleSome()
         {
             // Arrange
             var s = "p1.2";

--- a/Fambda.Tests/Core/FloatTypeTests.cs
+++ b/Fambda.Tests/Core/FloatTypeTests.cs
@@ -12,7 +12,7 @@ namespace Fambda
         #region Parse
 
         [Fact]
-        public void ParseShouldReturnOptionFloatNone()
+        public void Parse_ReturnsOptionFloatNone()
         {
             // Arrange
             var s = "not a float";
@@ -26,7 +26,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionFloatSome()
+        public void Parse_ReturnsOptionFloatSome()
         {
             // Arrange
             var s = "1.1";
@@ -40,7 +40,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionFloatNone()
+        public void Parse_WithNumberStyles_ReturnsOptionFloatNone()
         {
             // Arrange
             var s = "not a float";
@@ -54,7 +54,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionFloatSome()
+        public void Parse_WithNumberStyles_ReturnsOptionFloatSome()
         {
             // Arrange
             var s = "1.1";
@@ -68,7 +68,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionFloatNoneWhenStringIsNotExpectedHexNumber()
+        public void Parse_WithNumberStylesWhenStringIsNotExpectedHexNumber_ReturnsOptionFloatNone()
         {
             // Arrange
             var s = "1.0";
@@ -82,7 +82,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionFloatNone()
+        public void Parse_WithFormatProvider_ReturnsOptionFloatNone()
         {
             // Arrange
             var s = "positive1234";
@@ -98,7 +98,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionFloatSome()
+        public void Parse_WithFormatProvider_ReturnsOptionFloatSome()
         {
             // Arrange
             var s = "p1234";
@@ -114,7 +114,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesAndFormatProviderShouldReturnOptionFloatNone()
+        public void Parse_WithNumberStylesAndFormatProvider_ReturnsOptionFloatNone()
         {
             // Arrange
             var s = "p1$234";
@@ -129,7 +129,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesAndFormatProviderShouldReturnOptionFloatSome()
+        public void Parse_WithNumberStylesAndFormatProvider_ReturnsOptionFloatSome()
         {
             // Arrange
             var s = "p1";

--- a/Fambda.Tests/Core/GuidTypeTests.cs
+++ b/Fambda.Tests/Core/GuidTypeTests.cs
@@ -11,7 +11,7 @@ namespace Fambda
         #region Parse
 
         [Fact]
-        public void ParseShouldReturnOptionGuidNone()
+        public void Parse_ReturnsOptionGuidNone()
         {
             // Arrange
             var input = "not a Guid";
@@ -25,7 +25,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionGuidSomeWhenInputFormat32Digits()
+        public void Parse_WhenInputFormat32Digits_ReturnsOptionGuidSome()
         {
             // Arrange
             var originalGuid = Guid.NewGuid();
@@ -40,7 +40,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionGuidSomeWhenInputFormat32DigitsSeparatedByHyphens()
+        public void Parse_WhenInputFormat32DigitsSeparatedByHyphens_ReturnsOptionGuidSome()
         {
             // Arrange
             var originalGuid = Guid.NewGuid();
@@ -55,7 +55,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionGuidSomeWhenInputFormat32DigitsSeparatedByHyphensEnclosedInBraces()
+        public void Parse_WhenInputFormat32DigitsSeparatedByHyphensEnclosedInBraces_ReturnsOptionGuidSome()
         {
             // Arrange
             var originalGuid = Guid.NewGuid();
@@ -70,7 +70,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionGuidSomeWhenInputFormat32DigitsSeparatedByHyphensEnclosedInParentheses()
+        public void Parse_WhenInputFormat32DigitsSeparatedByHyphensEnclosedInParentheses_ReturnsOptionGuidSome()
         {
             // Arrange
             var originalGuid = Guid.NewGuid();
@@ -85,7 +85,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionGuidSomeWhenInputFormat4HexadecimalsEnclosedInBracesWithTheFourthSubsetOf8HexadecimalsEnclosedInBraces()
+        public void Parse_WhenInputFormat4HexadecimalsEnclosedInBracesWithTheFourthSubsetOf8HexadecimalsEnclosedInBraces_ReturnsOptionGuidSome()
         {
             // Arrange
             var originalGuid = Guid.NewGuid();

--- a/Fambda.Tests/Core/IntTypeTests.cs
+++ b/Fambda.Tests/Core/IntTypeTests.cs
@@ -12,7 +12,7 @@ namespace Fambda
         #region Parse
 
         [Fact]
-        public void ParseShouldReturnOptionIntNone()
+        public void Parse_ReturnsOptionIntNone()
         {
             // Arrange
             var s = "not an int";
@@ -26,7 +26,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionIntSome()
+        public void Parse_ReturnsOptionIntSome()
         {
             // Arrange
             var s = "1";
@@ -40,7 +40,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionIntNone()
+        public void Parse_WithNumberStyles_ReturnOptionIntNone()
         {
             // Arrange
             var s = "not an int";
@@ -54,7 +54,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionIntSome()
+        public void Parse_WithNumberStyles_ReturnsOptionIntSome()
         {
             // Arrange
             var s = "1";
@@ -68,7 +68,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionIntNoneWhenStringIsNotExpectedHexNumber()
+        public void Parse_WithNumberStylesWhenStringIsNotExpectedHexNumber_ReturnsOptionIntNone()
         {
             // Arrange
             var s = "1.0";
@@ -82,7 +82,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionIntNone()
+        public void Parse_WithFormatProvider_ReturnsOptionIntNone()
         {
             // Arrange
             var s = "positive1234";
@@ -98,7 +98,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionIntSome()
+        public void Parse_WithFormatProvider_ReturnsOptionIntSome()
         {
             // Arrange
             var s = "p1234";
@@ -114,7 +114,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesAndFormatProviderShouldReturnOptionIntNone()
+        public void Parse_WithNumberStylesAndFormatProvider_ReturnsOptionIntNone()
         {
             // Arrange
             var s = "p1$234";
@@ -129,7 +129,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesAndFormatProviderShouldReturnOptionIntSome()
+        public void Parse_WithNumberStylesAndFormatProvider_ReturnsOptionIntSome()
         {
             // Arrange
             var s = "p1";

--- a/Fambda.Tests/Core/LongTypeTests.cs
+++ b/Fambda.Tests/Core/LongTypeTests.cs
@@ -12,7 +12,7 @@ namespace Fambda
         #region Parse
 
         [Fact]
-        public void ParseShouldReturnOptionLongNone()
+        public void Parse_ReturnsOptionLongNone()
         {
             // Arrange
             var s = "not a long";
@@ -26,7 +26,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseShouldReturnOptionLongSome()
+        public void Parse_ReturnsOptionLongSome()
         {
             // Arrange
             var s = "1";
@@ -40,7 +40,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionLongNone()
+        public void Parse_WithNumberStyles_ReturnsOptionLongNone()
         {
             // Arrange
             var s = "not a long";
@@ -54,7 +54,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionLongSome()
+        public void Parse_WithNumberStyles_ReturnOptionLongSome()
         {
             // Arrange
             var s = "1";
@@ -68,7 +68,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesShouldReturnOptionLongNoneWhenStringIsNotExpectedHexNumber()
+        public void Parse_WithNumberStylesWhenStringIsNotExpectedHexNumber_ReturnsOptionLongNone()
         {
             // Arrange
             var s = "1.0";
@@ -82,7 +82,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionLongNone()
+        public void Parse_WithFormatProvider_ReturnsOptionLongNone()
         {
             // Arrange
             var s = "positive1234";
@@ -98,7 +98,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithFormatProviderShouldReturnOptionLongSome()
+        public void Parse_WithFormatProvider_ReturnsOptionLongSome()
         {
             // Arrange
             var s = "p1234";
@@ -114,7 +114,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesAndFormatProviderShouldReturnOptionLongNone()
+        public void Parse_WithNumberStylesAndFormatProvider_ReturnsOptionLongNone()
         {
             // Arrange
             var s = "p1$234";
@@ -129,7 +129,7 @@ namespace Fambda
         }
 
         [Fact]
-        public void ParseWithNumberStylesAndFormatProviderShouldReturnOptionLongSome()
+        public void Parse_WithNumberStylesAndFormatProvider_ReturnsOptionLongSome()
         {
             // Arrange
             var s = "p1";


### PR DESCRIPTION
notes:
   make use of previously established convention
   for naming unit tests