### PR TITLE
C# 10.0 and nullable reference types (#278)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
 	<PropertyGroup>
+		<LangVersion>10.0</LangVersion>
 		<Nullable>enable</Nullable>
+		<WarningsAsErrors>CS8604</WarningsAsErrors>
 	</PropertyGroup>
 </Project>

--- a/Fambda.Tests/Concepts/EqComponentTests.ApplyEqualsOfTToNull.cs
+++ b/Fambda.Tests/Concepts/EqComponentTests.ApplyEqualsOfTToNull.cs
@@ -24,7 +24,7 @@ namespace Fambda.Concepts
         public void ApplyEqualsOfTToNullMustReturnExpectedResultForClassObjectDefaultNull()
         {
             // Arrange
-            BikeDumbClassObject bikeClassObject = default;
+            BikeDumbClassObject? bikeClassObject = default;
 
             // Act
             var result = EqComponent.ApplyEqualsOfTToNull<BikeDumbClassObject>(bikeClassObject);

--- a/Fambda.Tests/Concepts/EqComponentTests.ApplyOperatorEqualityToNull.cs
+++ b/Fambda.Tests/Concepts/EqComponentTests.ApplyOperatorEqualityToNull.cs
@@ -37,7 +37,7 @@ namespace Fambda.Concepts
         public void ApplyOperatorEqualityToNullMustReturnExpectedResultForClassOperatorObjectDefaultNull()
         {
             // Arrange
-            BikeOperatorClassObject bikeOperatorClassObject = default;
+            BikeOperatorClassObject? bikeOperatorClassObject = default;
 
             // Act
             var result = EqComponent.ApplyOperatorEqualityToNull<BikeOperatorClassObject>(bikeOperatorClassObject);

--- a/Fambda.Tests/Concepts/Objects/BikeClassObject.cs
+++ b/Fambda.Tests/Concepts/Objects/BikeClassObject.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Fambda.Concepts.Objects
 {
@@ -41,9 +40,9 @@ namespace Fambda.Concepts.Objects
         public static bool operator !=(BikeClassObject lhs, BikeClassObject rhs)
             => !(lhs == rhs);
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            if (obj == null || obj.GetType() != GetType())
+            if (obj is null || obj.GetType() != GetType())
             {
                 return false;
             }
@@ -53,16 +52,7 @@ namespace Fambda.Concepts.Objects
         }
 
 
-        public bool Equals([AllowNull] BikeClassObject other)
-        {
-            var result = false;
-
-            if (other != null)
-            {
-                result = Brand == other.Brand && Model == other.Model;
-            }
-
-            return result;
-        }
+        public bool Equals(BikeClassObject? other)
+            => other is not null && Brand == other.Brand && Model == other.Model;
     }
 }

--- a/Fambda.Tests/Contracts/GuardTests.cs
+++ b/Fambda.Tests/Contracts/GuardTests.cs
@@ -1,5 +1,4 @@
 using System;
-using Fambda.Contracts;
 using FluentAssertions;
 using Xunit;
 
@@ -27,7 +26,7 @@ namespace Fambda.Contracts
         {
             // Arrange
             string value = null;
-            GuardException guardException = null;
+            GuardException? guardException = null;
 
             // Act
             Action ctor = () => new Guard<string>(value, guardException);

--- a/Fambda.Tests/Core/Exceptional/ExceptionalTests.cs
+++ b/Fambda.Tests/Core/Exceptional/ExceptionalTests.cs
@@ -28,7 +28,7 @@ namespace Fambda
         public void ImplicitOperatorOverloadingShouldThrowWhenExceptionIsNull()
         {
             // Arrange
-            SomeException exception = null;
+            SomeException? exception = null;
 
             // Act
             Action act = () => { Exceptional<string> exceptional = exception; };

--- a/Fambda.Tests/Core/Option/OptionSomeTests.cs
+++ b/Fambda.Tests/Core/Option/OptionSomeTests.cs
@@ -24,10 +24,10 @@ namespace Fambda
         public void Constructor_NullValue_ThrowsOptionSomeValueMustNotBeNullException()
         {
             // Arrange
-            string value = null;
+            string? value = null;
 
             // Act
-            Action ctor = () => new OptionSome<string>(value);
+            Action ctor = () => new OptionSome<string?>(value);
 
             // Assert
             ctor.Should().Throw<OptionSomeValueMustNotBeNullException>();

--- a/Fambda.Tests/Helpers/EqComponent.cs
+++ b/Fambda.Tests/Helpers/EqComponent.cs
@@ -29,7 +29,7 @@ namespace Fambda.Helpers
             });
         }
 
-        internal static EqResult ApplyEqualsToNull<T>(T obj)
+        internal static EqResult ApplyEqualsToNull<T>(T? obj)
         {
             if (typeof(T).IsClass)
             {
@@ -38,12 +38,12 @@ namespace Fambda.Helpers
             return EqResult.Success();
         }
 
-        internal static EqResult ApplyEqualsOfTToNull<T>(T obj)
+        internal static EqResult ApplyEqualsOfTToNull<T>(T? obj)
         {
             return ApplyEqualsToNull<T>(obj);
         }
 
-        internal static EqResult ApplyEquals<T>(T objA, T objB, bool expectedEqualObjects)
+        internal static EqResult ApplyEquals<T>(T? objA, T? objB, bool expectedEqualObjects)
         {
             return GetEqResult("Equals", () =>
             {
@@ -59,11 +59,11 @@ namespace Fambda.Helpers
             });
         }
 
-        internal static EqResult ApplyEqualsOfT<T>(T objA, T objB, bool expectedEqualObjects)
+        internal static EqResult ApplyEqualsOfT<T>(T? objA, T objB, bool expectedEqualObjects)
         {
             if (objA is IEquatable<T>)
             {
-                return ApplyEqualsOfTOnIEquatable<T>(objA as IEquatable<T>, objB, expectedEqualObjects);
+                return ApplyEqualsOfTOnIEquatable<T>((IEquatable<T>)objA, objB, expectedEqualObjects);
             }
             return EqResult.Success();
         }
@@ -84,7 +84,7 @@ namespace Fambda.Helpers
             });
         }
 
-        internal static EqResult ApplyOperatorEqualityToNull<T>(T obj)
+        internal static EqResult ApplyOperatorEqualityToNull<T>(T? obj)
         {
             if (typeof(T).IsClass)
             {
@@ -93,7 +93,7 @@ namespace Fambda.Helpers
             return EqResult.Success();
         }
 
-        internal static EqResult ApplyOperatorEquality<T>(T objA, T objB, bool expectedEqualObjects)
+        internal static EqResult ApplyOperatorEquality<T>(T? objA, T? objB, bool expectedEqualObjects)
         {
             var operatorEquality = EqReflector.GetOperatorEquality<T>();
             if (operatorEquality == null)
@@ -103,7 +103,7 @@ namespace Fambda.Helpers
             return ApplyOperatorEquality<T>(objA, objB, expectedEqualObjects, operatorEquality);
         }
 
-        internal static EqResult ApplyOperatorEquality<T>(T objA, T objB, bool expectedEqualObjects, MethodInfo operatorEquality)
+        internal static EqResult ApplyOperatorEquality<T>(T? objA, T? objB, bool expectedEqualObjects, MethodInfo operatorEquality)
         {
             return GetEqResult("Operator ==", () =>
             {
@@ -128,7 +128,7 @@ namespace Fambda.Helpers
             return EqResult.Success();
         }
 
-        internal static EqResult ApplyOperatorInequality<T>(T objA, T objB, bool expectedUnequalObjects)
+        internal static EqResult ApplyOperatorInequality<T>(T objA, T? objB, bool expectedUnequalObjects)
         {
             var operatorInequality = EqReflector.GetOperatorInequality<T>();
             if (operatorInequality == null)
@@ -138,7 +138,7 @@ namespace Fambda.Helpers
             return ApplyOperatorInequality<T>(objA, objB, expectedUnequalObjects, operatorInequality);
         }
 
-        internal static EqResult ApplyOperatorInequality<T>(T objA, T objB, bool expectedUnequalObjects, MethodInfo operatorInequality)
+        internal static EqResult ApplyOperatorInequality<T>(T objA, T? objB, bool expectedUnequalObjects, MethodInfo operatorInequality)
         {
             return GetEqResult("Operator !=", () =>
             {

--- a/Fambda/Contracts/Error.cs
+++ b/Fambda/Contracts/Error.cs
@@ -32,6 +32,11 @@ namespace Fambda.Contracts
             return new ExceptionalExceptionMustNotBeNullException();
         }
 
+        internal static ExceptionalValueMustNotBeNullException ExceptionalValueMustNotBeNull()
+        {
+            return new ExceptionalValueMustNotBeNullException();
+        }
+
         internal static EnumerationKeyMustNotBeNullException EnumerationKeyMustNotBeNull()
         {
             return new EnumerationKeyMustNotBeNullException();

--- a/Fambda/Contracts/ExceptionMessage.cs
+++ b/Fambda/Contracts/ExceptionMessage.cs
@@ -8,6 +8,7 @@ namespace Fambda.Contracts
         internal const string OptionValueMustNotBeNull = "Option value must not be null.";
         internal const string OptionMatchReturnMustNotBeNull = "Option.Match return must not be null.";
         internal const string ExceptionalExceptionMustNotBeNull = "Exceptional exception must not be null.";
+        internal const string ExceptionalValueMustNotBeNull = "Exceptional value must not be null.";
         internal const string EnumerationKeyMustNotBeNull = "Enumeration key must not be null.";
         internal const string EnumerationKeyMustNotBeEmpty = "Enumeration key must not be empty.";
         internal const string EnumerationKeyMustNotBeWhiteSpace = "Enumeration key must not be white space.";

--- a/Fambda/Contracts/Exceptions/ExceptionalValueMustNotBeNullException.cs
+++ b/Fambda/Contracts/Exceptions/ExceptionalValueMustNotBeNullException.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Fambda.Contracts
+{
+    /// <summary>
+    /// The exception that is thrown when Exceptional Value is null.
+    /// </summary>
+    [Serializable]
+    public class ExceptionalValueMustNotBeNullException : GuardException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExceptionalValueMustNotBeNullException"/> class.
+        /// </summary>
+        public ExceptionalValueMustNotBeNullException() : base(ExceptionMessage.ExceptionalValueMustNotBeNull) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExceptionalValueMustNotBeNullException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        /// <exception cref="ArgumentNullException">The info parameter is null.</exception>
+        /// <exception cref="SerializationException">The class name is null or System.Exception.HResult is zero (0).</exception>
+        protected ExceptionalValueMustNotBeNullException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+}

--- a/Fambda/Contracts/Guard{T}.cs
+++ b/Fambda/Contracts/Guard{T}.cs
@@ -9,12 +9,12 @@ namespace Fambda.Contracts
         /// <summary>
         /// Value to guard.
         /// </summary>
-        public T Value { get; }
+        public T? Value { get; }
 
         /// <summary>
         /// Object values to guard.
         /// </summary>
-        public object[] Values { get; }
+        public object?[]? Values { get; }
 
         /// <summary>
         /// <see cref="GuardException"/>
@@ -26,9 +26,9 @@ namespace Fambda.Contracts
         /// </summary>
         /// <param name="value"><typeparamref name="T"/> value</param>
         /// <param name="guardException"><see cref="GuardException"/></param>
-        public Guard(T value, GuardException guardException)
+        public Guard(T? value, GuardException? guardException)
         {
-            if (guardException == null)
+            if (guardException is null)
             {
                 throw Error.GuardExceptionMustNotBeNull();
             }
@@ -42,9 +42,9 @@ namespace Fambda.Contracts
         /// </summary>
         /// <param name="values">Object values</param>
         /// <param name="guardException"><see cref="GuardException"/></param>
-        public Guard(object[] values, GuardException guardException)
+        public Guard(object?[]? values, GuardException? guardException)
         {
-            if (guardException == null)
+            if (guardException is null)
             {
                 throw Error.GuardExceptionMustNotBeNull();
             }

--- a/Fambda/Core/Exceptional/Exceptional.cs
+++ b/Fambda/Core/Exceptional/Exceptional.cs
@@ -12,10 +12,10 @@ namespace Fambda
     /// <typeparam name="T">The type of the value to be wrapped.</typeparam>
     public struct Exceptional<T> : IEquatable<Exceptional<T>>
     {
-        internal Exception Exception { get; }
-        internal T Value { get; }
+        internal Exception? Exception { get; }
+        internal T? Value { get; }
 
-        internal Exceptional(Exception exception)
+        internal Exceptional(Exception? exception)
         {
             Guard.On(exception, Error.ExceptionalExceptionMustNotBeNull()).AgainstNull();
 
@@ -23,8 +23,10 @@ namespace Fambda
             Value = default;
         }
 
-        internal Exceptional(T value)
+        internal Exceptional(T? value)
         {
+            Guard.On(value, Error.ExceptionalValueMustNotBeNull()).AgainstNull();
+
             Exception = null;
             Value = value;
         }
@@ -33,14 +35,14 @@ namespace Fambda
         /// Implicit conversion operator from <see cref="Exception"/> to <see cref="Exceptional{T}"/>.
         /// </summary>
         /// <param name="exception"><see cref="Exception"/> object.</param>
-        public static implicit operator Exceptional<T>(Exception exception)
+        public static implicit operator Exceptional<T>(Exception? exception)
             => new Exceptional<T>(exception);
 
         /// <summary>
         /// Implicit conversion operator from <typeparamref name="T"/> to <see cref="Exceptional{T}"/>.
         /// </summary>
         /// <param name="value">T value.</param>
-        public static implicit operator Exceptional<T>(T value)
+        public static implicit operator Exceptional<T>(T? value)
             => new Exceptional<T>(value);
 
         /// <summary>
@@ -50,7 +52,7 @@ namespace Fambda
         /// <param name="Exception">Exception match operation.</param>
         /// <param name="Success">Success match operation.</param>
         public Res Match<Res>(Func<Exception, Res> Exception, Func<T, Res> Success)
-            => this.Exception != null ? Exception(this.Exception) : Success(this.Value);
+            => this.Exception is not null ? Exception(this.Exception!) : Success(this.Value!);
 
         /// <summary>
         /// Match the Exception and Success of the <see cref="Exceptional{T}"/> and return Res.
@@ -59,7 +61,7 @@ namespace Fambda
         /// <param name="Exception">Exception match operation.</param>
         /// <param name="Success">Success match operation.</param>
         public async Task<Res> Match<Res>(Func<Exception, Res> Exception, Func<T, Task<Res>> Success)
-            => this.Exception != null ? await Task.FromResult(Exception(this.Exception)) : await Success(this.Value).ConfigureAwait(false);
+            => this.Exception is not null ? await Task.FromResult(Exception(this.Exception!)) : await Success(this.Value!).ConfigureAwait(false);
 
         /// <summary>
         /// Calculates the hash-code based on whether <see cref="Exceptional{T}"/> is in Exception or Success.
@@ -99,7 +101,7 @@ namespace Fambda
         /// </summary>
         /// <param name="obj">The object to compare with the current <see cref="Exceptional{T}"/> object.</param>
         /// <returns>true if the specified object is equal to the current <see cref="Exceptional{T}"/> object; otherwise, false.</returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (IsNull(obj)) { return false; }
             else if (obj is Exceptional<T> exceptional) { return Equals(exceptional); }

--- a/Fambda/Core/Exceptional/ExceptionalExt.cs
+++ b/Fambda/Core/Exceptional/ExceptionalExt.cs
@@ -13,7 +13,7 @@ namespace Fambda
         /// Maps <see cref="Exceptional{T}"/> into <see cref="Exceptional{Res}"/>
         /// </summary>
         public static Exceptional<Res> Map<R, Res>(this Exceptional<R> self, Func<R, Res> func)
-            => self.Exception == null ? func(self.Value) : new Exceptional<Res>(self.Exception);
+            => self.Exception is null ? func(self.Value!) : new Exceptional<Res>(self.Exception);
 
         #endregion
 
@@ -23,7 +23,7 @@ namespace Fambda
         /// Binds <see cref="Exceptional{T}"/> into <see cref="Exceptional{Res}"/>
         /// </summary>
         public static Exceptional<Res> Bind<R, Res>(this Exceptional<R> self, Func<R, Exceptional<Res>> func)
-            => self.Exception == null ? func(self.Value) : new Exceptional<Res>(self.Exception);
+            => self.Exception is null ? func(self.Value!) : new Exceptional<Res>(self.Exception);
 
         #endregion
 

--- a/Fambda/Core/Option/Option.cs
+++ b/Fambda/Core/Option/Option.cs
@@ -94,7 +94,7 @@ namespace Fambda
         /// </summary>
         /// <param name="obj">The object to compare with the current <see cref="Option{T}"/> object.</param>
         /// <returns>true if the specified object is equal to the current <see cref="Option{T}"/> object; otherwise, false.</returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => (obj is OptionNone optionNone && Equals(optionNone)) ||
                (obj is OptionSome<T> optionSome && Equals(optionSome)) ||
                (obj is Option<T> option && Equals(option));

--- a/Fambda/Core/Option/OptionNone.cs
+++ b/Fambda/Core/Option/OptionNone.cs
@@ -36,7 +36,7 @@ namespace Fambda
         /// <param name="obj">The object to compare with the current <see cref="OptionNone"/> object.</param>
         /// <returns>true if the specified object is equal to the current <see cref="OptionNone"/> object; otherwise, false.</returns>
         [Pure]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is OptionNone;
 
         /// <summary>

--- a/Fambda/Core/Option/OptionSome.cs
+++ b/Fambda/Core/Option/OptionSome.cs
@@ -25,7 +25,7 @@ namespace Fambda
         /// <returns>A hash code for the current <see cref="OptionSome{T}"/> object.</returns>
         [Pure]
         public override int GetHashCode()
-            => Value.GetHashCode();
+            => Value!.GetHashCode();
 
         /// <summary>
         /// Indicates whether the current <see cref="OptionSome{T}"/> is equal to another <see cref="OptionSome{T}"/>
@@ -34,7 +34,7 @@ namespace Fambda
         /// <returns>true if the current <see cref="OptionSome{T}"/> object is equal to the other parameter; otherwise, false.</returns>
         [Pure]
         public bool Equals(OptionSome<T> other)
-            => Value.Equals(other.Value);
+            => Value!.Equals(other.Value);
 
         /// <summary>
         /// Determines whether specified object is equal to the current <see cref="OptionSome{T}"/> object.
@@ -42,8 +42,8 @@ namespace Fambda
         /// <param name="obj">The object to compare with the current <see cref="OptionSome{T}"/> object.</param>
         /// <returns>true if the specified object is equal to the current <see cref="OptionSome{T}"/> object; otherwise, false.</returns>
         [Pure]
-        public override bool Equals(object obj)
-            => obj is OptionSome<T> optionSome && Value.Equals(optionSome.Value);
+        public override bool Equals(object? obj)
+            => obj is OptionSome<T> optionSome && Value!.Equals(optionSome.Value);
 
         /// <summary>
         /// Returns a string that represents the current <see cref="OptionSome{T}"/> object.

--- a/Fambda/Core/Unit/Unit.cs
+++ b/Fambda/Core/Unit/Unit.cs
@@ -32,7 +32,7 @@ namespace Fambda
         /// <param name="obj">The object to compare with the current <see cref="Unit"/> object.</param>
         /// <returns>true if the specified object is equal to the current <see cref="Unit"/> object; otherwise, false.</returns>
         [Pure]
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => obj is Unit;
 
         /// <summary>

--- a/Fambda/Fambda.csproj
+++ b/Fambda/Fambda.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <DebugType>Full</DebugType>
     <ProjectGuid>70726f6a-7064-6164-6c69-46616d626461</ProjectGuid>
-    <LangVersion>8.0</LangVersion>
     <CodeAnalysisRuleSet>..\rulesets\solution.ruleset</CodeAnalysisRuleSet>
     <PackageId>Fambda</PackageId>
     <Title>Fambda</Title>


### PR DESCRIPTION
remarks:
 - start using nullable reference types introduced in C# 8.0
    + from C# 9.0 generics T? without constraint struct/class:
       https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references#generics

   see:
   https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references#nullable-contexts