### PR TITLE
Bind overload with Task return (#350)

### DIFF
--- a/Fambda.Tests/Core/Option/OptionExtTests.cs
+++ b/Fambda.Tests/Core/Option/OptionExtTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 
@@ -127,6 +128,93 @@ namespace Fambda
 
             // Act
             var result = option.Bind(toTrueBoolWhenOptionIntOne);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+
+        [Fact]
+        public async Task Bind_NoneToTaskReturningSome_ReturnsNone()
+        {
+            // Arrange
+            Option<int> option = None;
+
+            Func<int, Task<Option<bool>>> toTrueBoolWhenOptionIntOne = (i) =>
+            {
+                if (i.Equals(1))
+                {
+                    return TaskSucc(Some(true));
+                }
+                else
+                {
+                    Option<bool> none = None;
+                    return TaskSucc(none);
+                }
+            };
+
+            var expected = None;
+
+            // Act
+            var result = await option.Bind(toTrueBoolWhenOptionIntOne);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Fact()]
+        public async Task Bind_SomeToTaskReturningNone_ReturnsNone()
+        {
+            // Arrange
+            var value = 2;
+            Option<int> option = Some(value);
+
+            Func<int, Task<Option<bool>>> toTrueBoolWhenOptionIntOne = (i) =>
+            {
+                if (i.Equals(1))
+                {
+                    return TaskSucc(Some(true));
+                }
+                else
+                {
+                    Option<bool> none = None;
+                    return TaskSucc(none);
+                }
+            };
+
+            var expected = None;
+
+            // Act
+            var result = await option.Bind(toTrueBoolWhenOptionIntOne);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public async Task Bind_SomeToTaskReturningSome_ReturnsSome()
+        {
+            // Arrange
+            var value = 1;
+            Option<int> option = Some(value);
+
+            Func<int, Task<Option<bool>>> toTrueBoolWhenOptionIntOne = (i) =>
+            {
+                if (i.Equals(1))
+                {
+                    return TaskSucc(Some(true));
+                }
+                else
+                {
+                    Option<bool> none = None;
+                    return TaskSucc(none);
+                }
+            };
+
+            var expected = Some(true);
+
+            // Act
+            var result = await option.Bind(toTrueBoolWhenOptionIntOne);
 
             // Assert
             result.Should().Be(expected);

--- a/Fambda/Core/Option/OptionExt.cs
+++ b/Fambda/Core/Option/OptionExt.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using static Fambda.F;
 
 namespace Fambda
@@ -41,6 +42,17 @@ namespace Fambda
                       None: () => None,
                       Some: (t) => func(t)
                     );
+
+        /// <summary>
+        /// <para>Binds <see cref="Option{T}">Option&lt;T></see> into <see cref="Task{T}">Task&lt;Option&lt;Res>></see>.</para>
+        /// <para><c>Option&lt;T> → (T → Task&lt;Option&lt;Res>>) → Task&lt;Option&lt;Res>></c></para>
+        /// </summary>
+        public static Task<Option<Res>> Bind<T, Res>(this Option<T> self, Func<T, Task<Option<Res>>> func)
+            => self.Match(
+                      None: () => TaskSucc(new Option<Res>()),
+                      Some: (t) => func(t)
+                    );
+
 
         #endregion
 


### PR DESCRIPTION
remarks:
 - bind an `Option<T>` into a `Task<Option<Res>>`
 - function signature: Option<T> → (T → Task<Option<Res>> → Task<Option<Res>>
 - covered scenarios: * None bind Task with some return state -> Task<None> * Some bind Task with none return state -> Task<None> * Some bind Task with some return state -> Task<Some>