### PR TITLE
Declare immutable structs as readonly (#368)

### DIFF
--- a/Fambda/Core/Either/Either.cs
+++ b/Fambda/Core/Either/Either.cs
@@ -8,7 +8,7 @@ namespace Fambda
     /// </summary>
     /// <typeparam name="L">The type of the left value to be wrapped.</typeparam>
     /// <typeparam name="R">The type of the right value to be wrapped.</typeparam>
-    public struct Either<L, R> : IEquatable<Either<L, R>>
+    public readonly struct Either<L, R> : IEquatable<Either<L, R>>
     {
         internal L? Left { get; }
         internal R? Right { get; }

--- a/Fambda/Core/Either/EitherLeft.cs
+++ b/Fambda/Core/Either/EitherLeft.cs
@@ -7,7 +7,7 @@ namespace Fambda
     /// Represents an EitherLeft 'L' type.
     /// </summary>
     /// <typeparam name="L">The type of the left value to be wrapped.</typeparam>
-    public struct EitherLeft<L> : IEquatable<EitherLeft<L>>
+    public readonly struct EitherLeft<L> : IEquatable<EitherLeft<L>>
     {
         internal L Value { get; }
 

--- a/Fambda/Core/Either/EitherRight.cs
+++ b/Fambda/Core/Either/EitherRight.cs
@@ -7,7 +7,7 @@ namespace Fambda
     /// Represents an EitherRight 'R' type.
     /// </summary>
     /// <typeparam name="R">The type of the right value to be wrapped.</typeparam>
-    public struct EitherRight<R> : IEquatable<EitherRight<R>>
+    public readonly struct EitherRight<R> : IEquatable<EitherRight<R>>
     {
         internal R Value { get; }
 

--- a/Fambda/Core/Exceptional/Exceptional.cs
+++ b/Fambda/Core/Exceptional/Exceptional.cs
@@ -9,7 +9,7 @@ namespace Fambda
     /// Represents an Exceptional type.
     /// </summary>
     /// <typeparam name="T">The type of the value to be wrapped.</typeparam>
-    public struct Exceptional<T> : IEquatable<Exceptional<T>>
+    public readonly struct Exceptional<T> : IEquatable<Exceptional<T>>
     {
         internal Exception? Exception { get; }
         internal T? Value { get; }

--- a/Fambda/Core/Option/Option.cs
+++ b/Fambda/Core/Option/Option.cs
@@ -7,7 +7,7 @@ namespace Fambda
     /// Represents an Option type. 
     /// </summary>
     /// <typeparam name="T">The type of the value to be wrapped.</typeparam>
-    public struct Option<T> : IEquatable<Option<T>>, IEquatable<OptionNone>
+    public readonly struct Option<T> : IEquatable<Option<T>>, IEquatable<OptionNone>
     {
         private readonly T? _value;
         private readonly bool _isSome;

--- a/Fambda/Core/Option/OptionNone.cs
+++ b/Fambda/Core/Option/OptionNone.cs
@@ -6,7 +6,7 @@ namespace Fambda
     /// <summary>
     /// Represents an OptionNone type.
     /// </summary>
-    public struct OptionNone : IEquatable<OptionNone>
+    public readonly struct OptionNone : IEquatable<OptionNone>
     {
         private static readonly int _zero = 0;
 

--- a/Fambda/Core/Option/OptionSome.cs
+++ b/Fambda/Core/Option/OptionSome.cs
@@ -8,7 +8,7 @@ namespace Fambda
     /// Represents an OptionSome type.
     /// </summary>
     /// <typeparam name="T">The type of the value to be wrapped.</typeparam>
-    public struct OptionSome<T> : IEquatable<OptionSome<T>>
+    public readonly struct OptionSome<T> : IEquatable<OptionSome<T>>
     {
         internal T Value { get; }
 

--- a/Fambda/Core/Unit/Unit.cs
+++ b/Fambda/Core/Unit/Unit.cs
@@ -10,7 +10,7 @@ namespace Fambda
     /// This type that allows only one value (and thus can hold no information).
     /// See <a href="https://en.wikipedia.org/wiki/Unit_type">this link</a> for more information.
     /// </remarks>
-    public struct Unit : IEquatable<Unit>, IComparable<Unit>
+    public readonly struct Unit : IEquatable<Unit>, IComparable<Unit>
     {
         private static readonly int _zero = 0;
 


### PR DESCRIPTION
notes:
 - enforced through compiler following rules: 
    -  field members must be read-only 
    -  properties must be read-only (including auto-implemented properties)